### PR TITLE
ObjectSerializer should accept an options parameter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flick_json_api (1.7.0)
+    flick_json_api (1.7.1.pre)
       activesupport (>= 4.2)
 
 GEM

--- a/lib/flick_json_api/serializer.rb
+++ b/lib/flick_json_api/serializer.rb
@@ -46,5 +46,11 @@ module FlickJsonApi
     def attribute_documentation
       self.class.attribute_documentation
     end
+
+    # @deprecated upstream, but necessary to override here to prevent conflicts with Grape
+    # which expects to_json to accept an options parameter
+    def to_json(_options = {})
+      serialized_json
+    end
   end
 end

--- a/lib/flick_json_api/version.rb
+++ b/lib/flick_json_api/version.rb
@@ -1,3 +1,3 @@
 module FlickJsonApi
-  VERSION = "1.7.0"
+  VERSION = "1.7.1.pre"
 end


### PR DESCRIPTION
Grape calls to_json if the object responds to it, but passes in an options hash, which fast-jsonapi doesn't accept.

This workaround just ignores the options.

Fixes https://rollbar.com/FlickElectric/pricing/items/500/